### PR TITLE
if block can contain a parenthesis just after if

### DIFF
--- a/dbt_cleanup/refactor.py
+++ b/dbt_cleanup/refactor.py
@@ -225,7 +225,7 @@ def remove_unmatched_endings(sql_content: str) -> Tuple[str, List[str]]:
     # Regex patterns for Jinja tag matching
     JINJA_TAG_PATTERN = re.compile(r"{%-?\s*(.*?)\s*-?%}", re.DOTALL)
     MACRO_START = re.compile(r"macro\s+([^\s(]+)")  # Captures macro name
-    IF_START = re.compile(r"if\s+.*")
+    IF_START = re.compile(r"if[(\s]+.*")  # if blocks can also be {% if(...) %}
     MACRO_END = re.compile(r"endmacro")
     IF_END = re.compile(r"endif")
 

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -146,6 +146,18 @@ class TestUnmatchedEndingsRemoval:
         assert "{% endif %}" in result
         assert len(logs) == 0
 
+    def test_matched_if_with_parenthesis(self):
+        sql_content = """
+        {% if(condition) %}
+        select *
+        from my_table
+        {% endif %}
+        """
+        result, logs = remove_unmatched_endings(sql_content)
+        assert "if(condition)" in result
+        assert "{% endif %}" in result
+        assert len(logs) == 0
+
     def test_nested_structures(self):
         sql_content = """
         {% macro outer_macro() %}


### PR DESCRIPTION
- `{% if(test) %}` was not considered as valid `if` block with previous regex
- added a test as well