### PR TITLE
Handle case when a tag contains both if and macro strings

### DIFF
--- a/dbt_cleanup/refactor.py
+++ b/dbt_cleanup/refactor.py
@@ -223,11 +223,11 @@ def remove_unmatched_endings(sql_content: str) -> Tuple[str, List[str]]:
         - List of removal messages
     """
     # Regex patterns for Jinja tag matching
-    JINJA_TAG_PATTERN = re.compile(r"{%-?\s*(.*?)\s*-?%}", re.DOTALL)
-    MACRO_START = re.compile(r"macro\s+([^\s(]+)")  # Captures macro name
-    IF_START = re.compile(r"if[(\s]+.*")  # if blocks can also be {% if(...) %}
-    MACRO_END = re.compile(r"endmacro")
-    IF_END = re.compile(r"endif")
+    JINJA_TAG_PATTERN = re.compile(r"{%-?\s*((?s:.*?))\s*-?%}", re.DOTALL)
+    MACRO_START = re.compile(r"^macro\s+([^\s(]+)")  # Captures macro name
+    IF_START = re.compile(r"^if[(\s]+.*")  # if blocks can also be {% if(...) %}
+    MACRO_END = re.compile(r"^endmacro")
+    IF_END = re.compile(r"^endif")
 
     logs = []
     # Track macro and if states with their positions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,6 @@ test = [
 
 
 [tool.ruff]
-
-# Same as Black.
 line-length = 100
 indent-width = 4
 

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -158,6 +158,18 @@ class TestUnmatchedEndingsRemoval:
         assert "{% endif %}" in result
         assert len(logs) == 0
 
+    def test_matched_if_with_macro_in_name(self):
+        sql_content = """
+        {% if(macro_test) %}
+        select *
+        from my_table
+        {% endif %}
+        """
+        result, logs = remove_unmatched_endings(sql_content)
+        assert "if(macro_test)" in result
+        assert "{% endif %}" in result
+        assert len(logs) == 0
+
     def test_nested_structures(self):
         sql_content = """
         {% macro outer_macro() %}

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -95,6 +95,52 @@ models:
 """
 
 
+@pytest.fixture
+def schema_yml_with_fields_top_and_under_config():
+    return """
+version: 2
+
+models:
+  - name: my_first_dbt_model
+    description: "A starter dbt model"
+    materialized: table
+    database: my_db
+    schema: my_schema
+    config:
+      materialized: view # in that case, the materialization is view (tested on dbt-core)
+    meta:
+      abc: 123
+    columns:
+      - name: id
+        description: "The primary key for this table"
+        data_tests:
+          - unique
+          - not_null
+"""
+
+
+@pytest.fixture
+def schema_yml_with_close_matches():
+    return """
+version: 2
+
+models:
+  - name: my_first_dbt_model
+    description: "A starter dbt model"
+    materialize: table  # close to 'materialized'
+    zorderr: 30  # close to 'zorder'
+    config:
+      meta:
+        abc: 123
+    columns:
+      - name: id
+        description: "The primary key for this table"
+        data_tests:
+          - unique
+          - not_null
+"""
+
+
 class TestUnmatchedEndingsRemoval:
     """Tests for remove_unmatched_endings function"""
 
@@ -387,6 +433,64 @@ class TestYamlRefactoring:
         processed_files = {r.file_path for r in yaml_results}
         assert (models_dir / "schema.yml").resolve() in processed_files
         assert (sub_dir / "other_schema.yaml").resolve() in processed_files
+
+    def test_changeset_refactor_yml_with_fields_top_and_under_config(
+        self, temp_project_dir, schema_yml_with_fields_top_and_under_config
+    ):
+        # Create a test YAML file
+        yml_file = temp_project_dir / "models" / "schema.yml"
+        yml_file.parent.mkdir(parents=True, exist_ok=True)
+        yml_file.write_text(schema_yml_with_fields_top_and_under_config)
+
+        # Get the refactored result
+        result = changeset_refactor_yml(yml_file)
+
+        # Check that the file was refactored
+        assert result.refactored
+        assert isinstance(result, YMLRefactorResult)
+
+        # Check that config fields were moved under config
+        model = safe_load(result.refactored_yaml)["models"][0]
+
+        assert "materialized" not in model
+        assert model["config"]["materialized"] == "view"
+
+    def test_changeset_refactor_yml_with_close_matches(
+        self, temp_project_dir, schema_yml_with_close_matches
+    ):
+        # Create a test YAML file
+        yml_file = temp_project_dir / "models" / "schema.yml"
+        yml_file.parent.mkdir(parents=True, exist_ok=True)
+        yml_file.write_text(schema_yml_with_close_matches)
+
+        # Get the refactored result
+        result = changeset_refactor_yml(yml_file)
+
+        # Check that the file was refactored
+        assert result.refactored
+        assert isinstance(result, YMLRefactorResult)
+
+        # Check that fields were moved under config.meta
+        model = safe_load(result.refactored_yaml)["models"][0]
+
+        # Check that the original fields are removed from top level
+        assert "materialize" not in model
+        assert "zorder" not in model
+
+        # Check that fields were moved under config.meta
+        assert "config" in model
+        assert "meta" in model["config"]
+        assert model["config"]["meta"]["materialize"] == "table"
+        assert model["config"]["meta"]["zorderr"] == 30
+
+        # Check that appropriate logs were generated
+        assert any(
+            "'materialize' is not allowed, but 'materialized' is" in log
+            for log in result.refactor_logs
+        )
+        assert any(
+            "'zorderr' is not allowed, but 'zorder' is" in log for log in result.refactor_logs
+        )
 
 
 class TestYamlOutput:


### PR DESCRIPTION
- Handle case when a tag contains both if and macro strings
- Handle cases where a config is set at the top level and under `config`
- Make sure that we recommend close matches